### PR TITLE
Report warning when using the package without invoking AddServices

### DIFF
--- a/DependencyInjection.Attributed.sln
+++ b/DependencyInjection.Attributed.sln
@@ -3,15 +3,17 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.4.32916.344
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DependencyInjection.Attributed", "src\DependencyInjection.Attributed\DependencyInjection.Attributed.csproj", "{9DF192DF-0330-4B82-81C5-B8E7B4D53E41}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Attributed", "src\DependencyInjection.Attributed\Attributed.csproj", "{9DF192DF-0330-4B82-81C5-B8E7B4D53E41}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DependencyInjection.Attributed.Tests", "src\DependencyInjection.Attributed.Tests\DependencyInjection.Attributed.Tests.csproj", "{F2E67084-FED3-4E17-A012-0E8948FD3E06}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Attributed.Tests", "src\DependencyInjection.Attributed.Tests\Attributed.Tests.csproj", "{F2E67084-FED3-4E17-A012-0E8948FD3E06}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{FE116B5E-AE0C-4901-B0FE-BE41EF18EF06}"
 	ProjectSection(SolutionItems) = preProject
 		src\Directory.props = src\Directory.props
 		readme.md = readme.md
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CodeAnalysis.Tests", "src\CodeAnalysis.Tests\CodeAnalysis.Tests.csproj", "{E512DEBA-FB35-47FD-AF25-3BAECCF667B1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -27,6 +29,10 @@ Global
 		{F2E67084-FED3-4E17-A012-0E8948FD3E06}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F2E67084-FED3-4E17-A012-0E8948FD3E06}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F2E67084-FED3-4E17-A012-0E8948FD3E06}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E512DEBA-FB35-47FD-AF25-3BAECCF667B1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E512DEBA-FB35-47FD-AF25-3BAECCF667B1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E512DEBA-FB35-47FD-AF25-3BAECCF667B1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E512DEBA-FB35-47FD-AF25-3BAECCF667B1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/CodeAnalysis.Tests/AddServicesAnalyzerTests.cs
+++ b/src/CodeAnalysis.Tests/AddServicesAnalyzerTests.cs
@@ -1,0 +1,227 @@
+﻿using System.Collections.Immutable;
+using System.IO;
+using System.Threading.Tasks;
+using Devlooped.Extensions.DependencyInjection.Attributed;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+using Xunit.Abstractions;
+using Test = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerTest<Devlooped.Extensions.DependencyInjection.Attributed.AddServicesAnalyzer, Microsoft.CodeAnalysis.Testing.Verifiers.XUnitVerifier>;
+using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<Devlooped.Extensions.DependencyInjection.Attributed.AddServicesAnalyzer, Microsoft.CodeAnalysis.Testing.Verifiers.XUnitVerifier>;
+
+namespace Tests.CodeAnalysis;
+
+public record AddServicesAnalyzerTests(ITestOutputHelper Output)
+{
+    [Fact]
+    public async Task NoWarningIfAddServicesPresent()
+    {
+        var test = new Test
+        {
+            TestCode = """
+            using System;
+            using Microsoft.Extensions.DependencyInjection;
+            
+            public record Command;
+            
+            public static class Program
+            {
+                public static void Main()
+                {
+                    var services = new ServiceCollection();
+                    services.AddServices();
+                }
+            }
+            """,
+            TestState =
+            {
+                ReferenceAssemblies = new ReferenceAssemblies(
+                    "net6.0",
+                    new PackageIdentity(
+                        "Microsoft.NETCore.App.Ref", "6.0.0"),
+                        Path.Combine("ref", "net6.0"))
+                    .AddPackages(ImmutableArray.Create(
+                        new PackageIdentity("Microsoft.Extensions.DependencyInjection", "6.0.0")))
+            },
+            CompilationTransforms =
+            {
+                (compilation, _) =>
+                {
+                    CSharpGeneratorDriver
+                        .Create(new StaticGenerator())
+                        .RunGeneratorsAndUpdateCompilation(compilation, out var staticPass, out var _);
+
+                    CSharpGeneratorDriver
+                        .Create(new IncrementalGenerator())
+                        .RunGeneratorsAndUpdateCompilation(staticPass, out var incrementalPass, out var _);
+
+                    return incrementalPass;
+                }
+            }
+        };
+
+        //var expected = Verifier.Diagnostic(AddServicesAnalyzer.NoAddServicesCall).WithLocation(0);
+
+        //test.ExpectedDiagnostics.Add(expected);
+        //test.ExpectedDiagnostics.Add(new DiagnosticResult("CS1503", DiagnosticSeverity.Error).WithLocation(0));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task NoWarningIfNoServiceCollectionCalls()
+    {
+        var test = new Test
+        {
+            TestCode = """
+            using System;
+            using Microsoft.Extensions.DependencyInjection;
+            
+            public record Command;
+            
+            public static class Program
+            {
+                public static void Main()
+                {
+                    Console.WriteLine("Hello World!");
+                }
+            }
+            """,
+            TestState =
+            {
+                ReferenceAssemblies = new ReferenceAssemblies(
+                    "net6.0",
+                    new PackageIdentity(
+                        "Microsoft.NETCore.App.Ref", "6.0.0"),
+                        Path.Combine("ref", "net6.0"))
+                    .AddPackages(ImmutableArray.Create(
+                        new PackageIdentity("Microsoft.Extensions.DependencyInjection.Abstractions", "6.0.0")))
+            },
+            CompilationTransforms =
+            {
+                (compilation, _) =>
+                {
+                    CSharpGeneratorDriver
+                        .Create(new StaticGenerator())
+                        .RunGeneratorsAndUpdateCompilation(compilation, out var staticPass, out var _);
+
+                    CSharpGeneratorDriver
+                        .Create(new IncrementalGenerator())
+                        .RunGeneratorsAndUpdateCompilation(staticPass, out var incrementalPass, out var _);
+
+                    return incrementalPass;
+                }
+            }
+        };
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task WarnIfAddServicesMissing()
+    {
+        var test = new Test
+        {
+            TestCode = """
+            using System;
+            using Microsoft.Extensions.DependencyInjection;
+            
+            public record Command;
+            
+            public static class Program
+            {
+                public static void Main()
+                {
+                    var services = new ServiceCollection();
+                    {|#0:services.AddSingleton(new Command())|};
+                }
+            }
+            """,
+            TestState =
+            {
+                ReferenceAssemblies = new ReferenceAssemblies(
+                    "net6.0",
+                    new PackageIdentity(
+                        "Microsoft.NETCore.App.Ref", "6.0.0"),
+                        Path.Combine("ref", "net6.0"))
+                    .AddPackages(ImmutableArray.Create(
+                        new PackageIdentity("Microsoft.Extensions.DependencyInjection", "6.0.0")))
+            },
+            CompilationTransforms =
+            {
+                (compilation, _) =>
+                {
+                    CSharpGeneratorDriver
+                        .Create(new StaticGenerator())
+                        .RunGeneratorsAndUpdateCompilation(compilation, out var staticPass, out var _);
+
+                    CSharpGeneratorDriver
+                        .Create(new IncrementalGenerator())
+                        .RunGeneratorsAndUpdateCompilation(staticPass, out var incrementalPass, out var _);
+
+                    return incrementalPass;
+                }
+            }
+        };
+
+        var expected = Verifier.Diagnostic(AddServicesAnalyzer.NoAddServicesCall).WithLocation(0);
+        test.ExpectedDiagnostics.Add(expected);
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task WarnIfAddServicesMissingMultipleLocations()
+    {
+        var test = new Test
+        {
+            TestCode = """
+            using System;
+            using Microsoft.Extensions.DependencyInjection;
+            
+            public record First;
+            public record Second;
+            
+            public static class Program
+            {
+                public static void Main()
+                {
+                    var services = new ServiceCollection();
+                    {|#0:services.AddSingleton(new First())|};
+                    services.AddSingleton(new Second());
+                }
+            }
+            """,
+            TestState =
+            {
+                ReferenceAssemblies = new ReferenceAssemblies(
+                    "net6.0",
+                    new PackageIdentity(
+                        "Microsoft.NETCore.App.Ref", "6.0.0"),
+                        Path.Combine("ref", "net6.0"))
+                    .AddPackages(ImmutableArray.Create(
+                        new PackageIdentity("Microsoft.Extensions.DependencyInjection", "6.0.0")))
+            },
+            CompilationTransforms =
+            {
+                (compilation, _) =>
+                {
+                    CSharpGeneratorDriver
+                        .Create(new StaticGenerator())
+                        .RunGeneratorsAndUpdateCompilation(compilation, out var staticPass, out var _);
+
+                    CSharpGeneratorDriver
+                        .Create(new IncrementalGenerator())
+                        .RunGeneratorsAndUpdateCompilation(staticPass, out var incrementalPass, out var _);
+
+                    return incrementalPass;
+                }
+            }
+        };
+
+        var expected = Verifier.Diagnostic(AddServicesAnalyzer.NoAddServicesCall).WithLocation(0);
+        test.ExpectedDiagnostics.Add(expected);
+
+        await test.RunAsync();
+    }
+}

--- a/src/CodeAnalysis.Tests/CodeAnalysis.Tests.csproj
+++ b/src/CodeAnalysis.Tests/CodeAnalysis.Tests.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>Preview</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.2-dev" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DependencyInjection.Attributed\Attributed.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/DependencyInjection.Attributed.Tests/Attributed.Tests.csproj
+++ b/src/DependencyInjection.Attributed.Tests/Attributed.Tests.csproj
@@ -9,18 +9,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="System.ComponentModel.Composition" Version="6.0.0" />
     <PackageReference Include="System.Composition.AttributedModel" Version="6.0.0" />
     <PackageReference Include="System.Composition.Hosting" Version="6.0.0" />
     <PackageReference Include="System.Composition.TypedParts" Version="6.0.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\DependencyInjection.Attributed\DependencyInjection.Attributed.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
+    <ProjectReference Include="..\DependencyInjection.Attributed\Attributed.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DependencyInjection.Attributed/AddServicesAnalyzer.cs
+++ b/src/DependencyInjection.Attributed/AddServicesAnalyzer.cs
@@ -1,0 +1,83 @@
+﻿using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Devlooped.Extensions.DependencyInjection.Attributed;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public class AddServicesAnalyzer : DiagnosticAnalyzer
+{
+    public static DiagnosticDescriptor NoAddServicesCall { get; } =
+        new DiagnosticDescriptor(
+        "DDI001",
+        "No call to IServiceCollection.AddServices found.",
+        "The AddServices extension method must be invoked in order for discovered services to be properly registered.",
+        "Build",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create(NoAddServicesCall);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+
+        var usesServiceCollection = false;
+        var usesAddServices = false;
+
+        context.RegisterCompilationStartAction(startContext =>
+        {
+            var servicesCollection = startContext.Compilation.GetTypeByMetadataName("Microsoft.Extensions.DependencyInjection.IServiceCollection");
+            if (servicesCollection == null)
+                return;
+
+            Location? location = default;
+
+            startContext.RegisterSemanticModelAction(semanticContext =>
+            {
+                var semantic = semanticContext.SemanticModel;
+                var invocations = semantic.SyntaxTree
+                    .GetRoot(semanticContext.CancellationToken)
+                    .DescendantNodes()
+                    .OfType<InvocationExpressionSyntax>()
+                    .Select(invocation => new { Invocation = invocation, semantic.GetSymbolInfo(invocation, semanticContext.CancellationToken).Symbol })
+                    .Where(x => x.Symbol is IMethodSymbol)
+                    .Select(x => new { x.Invocation, Method = (IMethodSymbol)x.Symbol! });
+
+                bool IsServiceCollectionExtension(IMethodSymbol method) => method.IsExtensionMethod &&
+                        method.ReducedFrom != null &&
+                        method.ReducedFrom.Parameters.Length > 0 &&
+                        method.ReducedFrom.Parameters[0].Type.Equals(servicesCollection, SymbolEqualityComparer.Default);
+
+                if (!usesServiceCollection &&
+                    invocations.Where(x => x.Method.ContainingType.Is(servicesCollection) || IsServiceCollectionExtension(x.Method))
+                    .FirstOrDefault() is { } invocation)
+                {
+                    // Remove diagnostic, we found an invocation
+                    usesServiceCollection = true;
+                    if (location == null)
+                        location = invocation.Invocation.GetLocation();
+                }
+
+                if (!usesAddServices &&
+                    invocations.Where(x =>
+                        IsServiceCollectionExtension(x.Method) &&
+                        x.Method.ReducedFrom!.GetAttributes().Any(attr => attr.AttributeClass?.Name == "DDIAddServicesAttribute"))
+                    .Any())
+                {
+                    usesAddServices = true;
+                }
+            });
+
+            startContext.RegisterCompilationEndAction(endContext =>
+            {
+                if (usesServiceCollection && !usesAddServices)
+                    endContext.ReportDiagnostic(Diagnostic.Create(NoAddServicesCall, location));
+            });
+        });
+    }
+}

--- a/src/DependencyInjection.Attributed/Attributed.csproj
+++ b/src/DependencyInjection.Attributed/Attributed.csproj
@@ -8,6 +8,7 @@
     <Title>Automatic compile-time service registrations for Microsoft.Extensions.DependencyInjection with no run-time dependencies.</Title>
     <Description>$(Title)</Description>
     <PackFolder>analyzers/dotnet</PackFolder>
+    <IsRoslynComponent>true</IsRoslynComponent>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DependencyInjection.Attributed/Devlooped.Extensions.DependencyInjection.Attributed.targets
+++ b/src/DependencyInjection.Attributed/Devlooped.Extensions.DependencyInjection.Attributed.targets
@@ -8,7 +8,7 @@
 
   <Target Name="_AddDDI_Constant" BeforeTargets="CoreCompile">
     <PropertyGroup>
-      <DefineConstants Condition="'$(Language)' == 'C#' and '$(AddServiceAttribute)' == 'true'">$(DefineConstants);DDI_ADDSERVICE</DefineConstants>
+      <DefineConstants Condition="'$(Language)' == 'C#' and '$(AddServiceAttribute)' == 'true' and !$(DefineConstants.Contains('DDI_ADDSERVICE'))">$(DefineConstants);DDI_ADDSERVICE</DefineConstants>
     </PropertyGroup>
   </Target>
   

--- a/src/DependencyInjection.Attributed/Properties/launchSettings.json
+++ b/src/DependencyInjection.Attributed/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "Roslyn": {
+      "commandName": "DebugRoslynComponent",
+      "targetProject": "..\\DependencyInjection.Attributed.Tests\\Attributed.Tests.csproj"
+    }
+  }
+}

--- a/src/DependencyInjection.Attributed/StaticGenerator.cs
+++ b/src/DependencyInjection.Attributed/StaticGenerator.cs
@@ -4,7 +4,7 @@ using Microsoft.CodeAnalysis;
 namespace Devlooped.Extensions.DependencyInjection.Attributed;
 
 [Generator(LanguageNames.CSharp)]
-class StaticGenerator : ISourceGenerator
+public class StaticGenerator : ISourceGenerator
 {
     public void Initialize(GeneratorInitializationContext context)
     {
@@ -53,6 +53,7 @@ class StaticGenerator : ISourceGenerator
 
         context.AddSource("AddServicesExtension.g",
           $$"""
+            using System;
             using System.ComponentModel;
             using Microsoft.Extensions.DependencyInjection;
 
@@ -70,6 +71,7 @@ class StaticGenerator : ISourceGenerator
                     /// </summary>
                     /// <param name="services">The <see cref="IServiceCollection"/> to add the services to.</param>
                     /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+                    [DDIAddServicesAttribute]
                     public static IServiceCollection AddServices(this IServiceCollection services)
                     {
                         AddScopedServices(services);
@@ -93,6 +95,9 @@ class StaticGenerator : ISourceGenerator
                     /// Adds discovered transient services to the collection.
                     /// </summary>
                     static partial void AddTransientServices(IServiceCollection services);
+
+                    [AttributeUsage(AttributeTargets.Method)]
+                    class DDIAddServicesAttribute : Attribute { }
                 }
             }
             """);

--- a/src/DependencyInjection.Attributed/SymbolExtensions.cs
+++ b/src/DependencyInjection.Attributed/SymbolExtensions.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.CodeAnalysis;
+
+static class SymbolExtensions
+{
+    /// <summary>
+    /// Checks whether the <paramref name="this"/> type inherits or implements the 
+    /// <paramref name="baseTypeOrInterface"/> type, even if it's a generic type.
+    /// </summary>
+    public static bool Is(this ITypeSymbol? @this, ITypeSymbol? baseTypeOrInterface)
+    {
+        if (@this == null || baseTypeOrInterface == null)
+            return false;
+
+        if (@this.Equals(baseTypeOrInterface, SymbolEqualityComparer.Default) == true)
+            return true;
+
+        if (baseTypeOrInterface is INamedTypeSymbol namedExpected &&
+            @this is INamedTypeSymbol namedActual &&
+            namedActual.IsGenericType &&
+            namedActual.ConstructedFrom.Equals(namedExpected, SymbolEqualityComparer.Default))
+            return true;
+
+        foreach (var iface in @this.AllInterfaces)
+            if (iface.Is(baseTypeOrInterface))
+                return true;
+
+        if (@this.BaseType?.Name.Equals("object", StringComparison.OrdinalIgnoreCase) == true)
+            return false;
+
+        return Is(@this.BaseType, baseTypeOrInterface);
+    }
+}


### PR DESCRIPTION
Conditions for reporting the warning are:

* Detect if users have access to IServiceCollection in the current project: it may be that they just added the package to get the [Service] attribute for a library. Nothing to do in that case.
* Detect if users actually invoke IServiceCollection members in the current project, more or less flexibly (i.e. don't verify much where specifically, since the DI library can be used in multiple contexts). If they do, then it's an indication that there should be a call to the AddServices extension method too somewhere. As a hint, report the location on the first invocation to a service collection method (or extension method).
* Report as a warning, since we can determine this wrong, depending on whether users are initializing services some other way or indirectly. This allows them to ignore the warning using the regular configuration mechanisms for analyzers and diagnostics.

Closes #30