### PR TITLE
Don't report warning for missing AddServices() in test projects

### DIFF
--- a/src/DependencyInjection.Attributed/AddServicesAnalyzer.cs
+++ b/src/DependencyInjection.Attributed/AddServicesAnalyzer.cs
@@ -78,6 +78,12 @@ public class AddServicesAnalyzer : DiagnosticAnalyzer
 
             startContext.RegisterCompilationEndAction(endContext =>
             {
+                var isTest = endContext.Options.AnalyzerConfigOptionsProvider.GlobalOptions.TryGetValue("build_property.IsTestProject", out var value) &&
+                    bool.TryParse(value, out var isTestProject) && isTestProject;
+
+                if (isTest)
+                    return;
+
                 if (usesServiceCollection && !usesAddServices)
                     endContext.ReportDiagnostic(Diagnostic.Create(NoAddServicesCall, location));
             });

--- a/src/DependencyInjection.Attributed/Devlooped.Extensions.DependencyInjection.Attributed.props
+++ b/src/DependencyInjection.Attributed/Devlooped.Extensions.DependencyInjection.Attributed.props
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <CompilerVisibleProperty Include="IsTestProject" />
     <CompilerVisibleProperty Include="AddServicesNamespace" />
     <CompilerVisibleProperty Include="AddServicesClassName" />
   </ItemGroup>

--- a/src/DependencyInjection.Attributed/Properties/launchSettings.json
+++ b/src/DependencyInjection.Attributed/Properties/launchSettings.json
@@ -1,6 +1,6 @@
 {
   "profiles": {
-    "Roslyn": {
+    "Tests": {
       "commandName": "DebugRoslynComponent",
       "targetProject": "..\\DependencyInjection.Attributed.Tests\\Attributed.Tests.csproj"
     },


### PR DESCRIPTION
Test projects have the IsTestProject=true via the required dependency on Microsoft.NET.Test.Sdk.

We leverage that property in the analyzer to never report this warning which is intended for the actual hosting projects.

Closes #47