### PR TITLE
Add Func<T> and Lazy<T> registrations

### DIFF
--- a/src/DependencyInjection.Attributed.Tests/GenerationTests.cs
+++ b/src/DependencyInjection.Attributed.Tests/GenerationTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
@@ -18,7 +19,12 @@ public record GenerationTests(ITestOutputHelper Output)
         var instance = services.GetRequiredService<SingletonService>();
 
         Assert.Same(instance, services.GetRequiredService<SingletonService>());
+        Assert.Same(instance, services.GetRequiredService<Func<SingletonService>>().Invoke());
+        Assert.Same(instance, services.GetRequiredService<Lazy<SingletonService>>().Value);
+
         Assert.Same(instance, services.GetRequiredService<IFormattable>());
+        Assert.Same(instance, services.GetRequiredService<Func<IFormattable>>().Invoke());
+        Assert.Same(instance, services.GetRequiredService<Lazy<IFormattable>>().Value);
     }
 
     [Fact]
@@ -31,7 +37,12 @@ public record GenerationTests(ITestOutputHelper Output)
         var instance = services.GetRequiredService<TransientService>();
 
         Assert.NotSame(instance, services.GetRequiredService<TransientService>());
+        Assert.NotSame(instance, services.GetRequiredService<Func<TransientService>>().Invoke());
+        Assert.NotSame(instance, services.GetRequiredService<Lazy<TransientService>>().Value);
+
         Assert.NotSame(instance, services.GetRequiredService<ICloneable>());
+        Assert.NotSame(instance, services.GetRequiredService<Func<ICloneable>>().Invoke());
+        Assert.NotSame(instance, services.GetRequiredService<Lazy<ICloneable>>().Value);
     }
 
     [Fact]
@@ -47,10 +58,17 @@ public record GenerationTests(ITestOutputHelper Output)
 
         // Within the scope, we get the same instance
         Assert.Same(instance, scope.ServiceProvider.GetRequiredService<ScopedService>());
+        Assert.Same(instance, scope.ServiceProvider.GetRequiredService<Func<ScopedService>>().Invoke());
+        Assert.Same(instance, scope.ServiceProvider.GetRequiredService<Lazy<ScopedService>>().Value);
+
         Assert.Same(instance, scope.ServiceProvider.GetRequiredService<IComparable>());
+        Assert.Same(instance, scope.ServiceProvider.GetRequiredService<Func<IComparable>>().Invoke());
+        Assert.Same(instance, scope.ServiceProvider.GetRequiredService<Lazy<IComparable>>().Value);
 
         // Outside the scope, we don't
         Assert.NotSame(instance, services.GetRequiredService<IComparable>());
+        Assert.NotSame(instance, services.GetRequiredService<Func<IComparable>>().Invoke());
+        Assert.NotSame(instance, services.GetRequiredService<Lazy<IComparable>>().Value);
     }
 
     [Fact]

--- a/src/DependencyInjection.Attributed/StaticGenerator.cs
+++ b/src/DependencyInjection.Attributed/StaticGenerator.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 
 namespace Devlooped.Extensions.DependencyInjection.Attributed;
 


### PR DESCRIPTION
Two patterns are quite typical when doing DI: lazy retrieval and factory-style retrieval (which might or might not return same instance, depending on dependency registration). There's a place for both, so this adds support for both.

The reasoning for making both registrations transient is that the lifetime of the underlying service is already determined by the implementation registration itself. Both Lazy and Func just delegate to the service provider at invocation time. This simplifies the potential cognitive overhead in understanding what happens for each.

If callers cache the Lazy<T>, they'd get single-time retrieval, regardless of the lifetime of the T (that is, the lifetime of the the lazy-initialized T is now tied to the dependency owner at that point.

At the same time, the Func<T> will either return a new T on each invocation or not, depending on how the T was registered. This might complicate things if T is disposable, since at that point the caller would need to know not to dispose retrieved instances inadvertently (since the container itself would do so at the right time). So such a dependency is generally advised for non-disposable services (or otherwise transient ones that can be safely disposed after each use via the Func<T>).

Closes #49