### PR TITLE
Generator shouldn't fail for unsuccessful compilation

### DIFF
--- a/src/DependencyInjection.Attributed/IncrementalGenerator.cs
+++ b/src/DependencyInjection.Attributed/IncrementalGenerator.cs
@@ -20,7 +20,7 @@ public class IncrementalGenerator : IIncrementalGenerator
     {
         var types = context.CompilationProvider.SelectMany((x, c) =>
         {
-            var visitor = new TypesVisitor(s => x.IsSymbolAccessibleWithin(s, x.Assembly), c);
+            var visitor = new TypesVisitor(s => x.IsSymbolAccessible(s), c);
             x.GlobalNamespace.Accept(visitor);
             // Also visit aliased references, which will not become part of the global:: namespace
             foreach (var symbol in x.References
@@ -149,7 +149,7 @@ public class IncrementalGenerator : IIncrementalGenerator
 
     void AddServices(ImmutableArray<INamedTypeSymbol> types, Compilation compilation, string methodName, StringBuilder output)
     {
-        bool isAccessible(ISymbol s) => compilation.IsSymbolAccessibleWithin(s, compilation.Assembly);
+        bool isAccessible(ISymbol s) => compilation.IsSymbolAccessible(s);
 
         foreach (var type in types)
         {

--- a/src/DependencyInjection.Attributed/SymbolExtensions.cs
+++ b/src/DependencyInjection.Attributed/SymbolExtensions.cs
@@ -19,6 +19,19 @@ static class SymbolExtensions
         genericsOptions: SymbolDisplayGenericsOptions.None,
         miscellaneousOptions: SymbolDisplayMiscellaneousOptions.ExpandNullable);
 
+    public static bool IsSymbolAccessible(this Compilation compilation, ISymbol symbol)
+    {
+        try
+        {
+            // Unfortunately, wrong assembly symbol throws instead of returning false :(
+            // See https://github.com/dotnet/roslyn/blob/9fef96ff1194f686993293c7971802216eb75a26/src/Compilers/Core/Portable/Compilation/Compilation.cs#L1626
+            return compilation.IsSymbolAccessibleWithin(symbol, compilation.Assembly);
+        }
+        catch
+        {
+            return false;
+        }
+    }
 
     public static string ToAssemblyNamespace(this INamespaceSymbol symbol)
         => symbol.ContainingAssembly.Name + "." + symbol.ToDisplayString(fullNameFormat);


### PR DESCRIPTION
In this scenario, the Compilation.IsSymbolAccessibleWithin is throwing at https://github.com/dotnet/roslyn/blob/9fef96ff1194f686993293c7971802216eb75a26/src/Compilers/Core/Portable/Compilation/Compilation.cs#L1626.

We account for that by providing our wrapping extension method that catches the exception and returns false instead (what we were expecting to get anyway).

Closes #51