### PR TITLE
Fix bug in codegen for transient keyed services

### DIFF
--- a/src/DependencyInjection.Attributed.Tests/GenerationTests.cs
+++ b/src/DependencyInjection.Attributed.Tests/GenerationTests.cs
@@ -150,6 +150,21 @@ public record GenerationTests(ITestOutputHelper Output)
         Assert.Same(singleton, instance.Dependency);
     }
 
+    [Fact]
+    public void ResolvesKeyedTransientDependency()
+    {
+        var collection = new ServiceCollection();
+        collection.AddServices();
+        var services = collection.BuildServiceProvider();
+
+        using var scope = services.CreateScope();
+
+        var first = scope.ServiceProvider.GetRequiredKeyedService<FromTransientKeyedDependency>("FromKeyedTransient");
+        var second = scope.ServiceProvider.GetRequiredKeyedService<FromTransientKeyedDependency>("FromKeyedTransient");
+
+        // Within the scope, we get the same instance
+        Assert.NotSame(first, second);
+    }
 
     [Fact]
     public void ResolvesKeyedDependencyForNonKeyed()
@@ -297,6 +312,12 @@ public class KeyedScopedService : IComparable
 
 [Service<string>("FromKeyed", ServiceLifetime.Scoped)]
 public class FromKeyedDependency([FromKeyedServices(42)] IFormattable dependency)
+{
+    public IFormattable Dependency => dependency;
+}
+
+[Service<string>("FromKeyedTransient", ServiceLifetime.Transient)]
+public class FromTransientKeyedDependency([FromKeyedServices(42)] IFormattable dependency)
 {
     public IFormattable Dependency => dependency;
 }

--- a/src/DependencyInjection.Attributed/IncrementalGenerator.cs
+++ b/src/DependencyInjection.Attributed/IncrementalGenerator.cs
@@ -314,7 +314,7 @@ public class IncrementalGenerator : IIncrementalGenerator
             }
 
             output.AppendLine($"            services.AddKeyedTransient<Func<{impl}>>({key}, (s, k) => () => s.GetRequiredKeyedService<{impl}>(k));");
-            output.AppendLine($"            services.AddKeyedTransient({key}, (s, k) => new Lazy<{impl}>(s.GetRequiredKeyedService<{impl}>(k)));");
+            output.AppendLine($"            services.AddKeyedTransient({key}, (s, k) => new Lazy<{impl}>(() => s.GetRequiredKeyedService<{impl}>(k)));");
 
             foreach (var iface in type.Type.AllInterfaces)
             {
@@ -323,7 +323,7 @@ public class IncrementalGenerator : IIncrementalGenerator
                 {
                     output.AppendLine($"            services.{methodName}<{ifaceName}>({key}, (s, k) => s.GetRequiredKeyedService<{impl}>(k));");
                     output.AppendLine($"            services.AddKeyedTransient<Func<{ifaceName}>>({key}, (s, k) => () => s.GetRequiredKeyedService<{ifaceName}>(k));");
-                    output.AppendLine($"            services.AddKeyedTransient({key}, (s, k) => new Lazy<{ifaceName}>(s.GetRequiredKeyedService<{ifaceName}>(k)));");
+                    output.AppendLine($"            services.AddKeyedTransient({key}, (s, k) => new Lazy<{ifaceName}>(() => s.GetRequiredKeyedService<{ifaceName}>(k)));");
                     registered.Add(ifaceName);
                 }
 
@@ -351,7 +351,7 @@ public class IncrementalGenerator : IIncrementalGenerator
                         {
                             output.AppendLine($"            services.{methodName}<{candidate}>({key}, (s, k) => s.GetRequiredKeyedService<{impl}>(k));");
                             output.AppendLine($"            services.AddKeyedTransient<Func<{candidate}>>({key}, (s, k) => () => s.GetRequiredKeyedService<{candidate}>(k));");
-                            output.AppendLine($"            services.AddKeyedTransient({key}, (s, k) => new Lazy<{candidate}>(k, s.GetRequiredKeyedService<{candidate}>(k)));");
+                            output.AppendLine($"            services.AddKeyedTransient({key}, (s, k) => new Lazy<{candidate}>(() => s.GetRequiredKeyedService<{candidate}>(k)));");
                             registered.Add(candidate);
                         }
                     }


### PR DESCRIPTION
We were generating a ctor invocation of Lazy<T> that didn't exist